### PR TITLE
Fix problem to match the solution

### DIFF
--- a/FormalisingMathematics2025/Section04sets/Sheet3.lean
+++ b/FormalisingMathematics2025/Section04sets/Sheet3.lean
@@ -40,7 +40,7 @@ example : A ⊆ B → x ∉ B → x ∉ A := by sorry
 -- to give it a hint by telling it the type of `∅`.
 example : x ∉ (∅ : Set X) := by sorry
 
-example : x ∈ Aᶜ → x ∉ A := by sorry
+example : x ∈ Aᶜ ↔ x ∉ A := by sorry
 
 example : (∀ x, x ∈ A) ↔ ¬∃ x, x ∈ Aᶜ := by sorry
 


### PR DESCRIPTION
The solution folder solves this by `rfl`:

https://github.com/b-mehta/formalising-mathematics-notes/blob/7d9f684e16e02e7fa261c1eebb4b8024ffc08c95/FormalisingMathematics2025/Solutions/Section04sets/Sheet3.lean#L51

But the original problem statement is only in one direction so this solution doesn't work. I'm not sure what the intended problem is, but I made it match the solution.