### PR TITLE
Fix tactic name in the comments

### DIFF
--- a/FormalisingMathematics2025/Section04sets/Sheet6.lean
+++ b/FormalisingMathematics2025/Section04sets/Sheet6.lean
@@ -42,7 +42,7 @@ example : S ⊆ f ⁻¹' (f '' S) := by sorry
 
 example : f '' (f ⁻¹' T) ⊆ T := by sorry
 
--- `library_search` will do this but see if you can do it yourself.
+-- `exact?` will do this but see if you can do it yourself.
 example : f '' S ⊆ T ↔ S ⊆ f ⁻¹' T := by sorry
 
 -- Pushforward and pullback along the identity map don't change anything

--- a/FormalisingMathematics2025/Section04sets/Sheet6.lean
+++ b/FormalisingMathematics2025/Section04sets/Sheet6.lean
@@ -49,7 +49,7 @@ example : f '' S ⊆ T ↔ S ⊆ f ⁻¹' T := by sorry
 -- pullback is not so hard
 example : id ⁻¹' S = S := by sorry
 
--- pushforward is a little trickier. You might have to `ext x, split`.
+-- pushforward is a little trickier. You might have to `ext x`, `constructor`.
 example : id '' S = S := by sorry
 
 -- Now let's try composition.

--- a/FormalisingMathematics2025/Section20algebraicNumberTheory/Sheet1.lean
+++ b/FormalisingMathematics2025/Section20algebraicNumberTheory/Sheet1.lean
@@ -74,7 +74,7 @@ satisfy the proposition `IsFractionRing ℤ A`.
 -- works fine
 example : IsFractionRing ℤ ℚ :=
   Rat.isFractionRing
--- thanks `library_search`
+-- thanks `exact?`
 
 example : FractionRing ℤ = ℚ :=
   sorry

--- a/FormalisingMathematics2025/Solutions/Section04sets/Sheet6.lean
+++ b/FormalisingMathematics2025/Solutions/Section04sets/Sheet6.lean
@@ -58,7 +58,7 @@ example : f '' S ⊆ T ↔ S ⊆ f ⁻¹' T := by
 -- pullback is not so hard
 example : id ⁻¹' S = S := by rfl
 
--- pushforward is a little trickier. You might have to `ext x, constructor`.
+-- pushforward is a little trickier. You might have to `ext x`, `constructor`.
 example : id '' S = S := by
   ext x
   constructor


### PR DESCRIPTION
Seems like `library_search` [used to be](https://proofassistants.stackexchange.com/a/415) a thing in Mathlib 3 but it's called `exact?` now.

Also `split` should say `constructor`.